### PR TITLE
Updating Country Codelist to match ISO Codelist

### DIFF
--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -780,7 +780,7 @@
         <codelist-item>
             <code>LY</code>
             <name>
-                <narrative>LIBYAN ARAB JAMAHIRIYA</narrative>
+                <narrative>LIBYA</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -1044,7 +1044,7 @@
         <codelist-item>
             <code>PS</code>
             <name>
-                <narrative>PALESTINIAN TERRITORY, OCCUPIED</narrative>
+                <narrative>PALESTINE, STATE OF</narrative>
             </name>
         </codelist-item>
         <codelist-item>


### PR DESCRIPTION
Updating Country Codelist to match 'short names' on ISO codelist.
Including changes to Libya, Palestine, Czechia, and some smaller changes.